### PR TITLE
Support maximum verification age

### DIFF
--- a/CredentialVerifier.sol
+++ b/CredentialVerifier.sol
@@ -9,12 +9,19 @@ contract CredentialVerifier {
 
     modifier requiresCredential(
         string memory expectedCredential,
-        bytes calldata signature,
-        uint validUntil
+        bytes calldata proof,
+        uint validUntil,
+        uint approvedAt,
+        uint maxAge
     ) {
         require (
             block.timestamp < validUntil,
             "Credential no longer valid"
+        );
+
+        require (
+            block.timestamp < approvedAt + maxAge,
+            "Approval not recent enough"
         );
 
         string memory sender = Strings.toHexString(uint256(uint160(msg.sender)), 20);
@@ -22,8 +29,8 @@ contract CredentialVerifier {
         require(
             SignatureChecker.isValidSignatureNow(
                 0x559FfB9C4AB5A552Ed2Ea814A84e74D4CFA21d34,
-                ECDSA.toEthSignedMessageHash(abi.encodePacked(Strings.toString(validUntil), ";", sender, ";", expectedCredential)),
-                signature
+                ECDSA.toEthSignedMessageHash(abi.encodePacked(Strings.toString(validUntil), ";", Strings.toString(approvedAt), ";", sender, ";", expectedCredential)),
+                proof
             ),
             "Signature doesn't match"
         );

--- a/CredentialVerifier.sol
+++ b/CredentialVerifier.sol
@@ -20,7 +20,7 @@ contract CredentialVerifier {
         );
 
         require (
-            block.timestamp < approvedAt + maxAge,
+            maxAge == 0 || block.timestamp < approvedAt + maxAge,
             "Approval not recent enough"
         );
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ GET https://credentials.fractal.id/
     ?message=<message user signed>
     &signature=<user signature>
 
-200 OK { proof: "<proof>", validUntil: <timestamp>, approvedAt: <timestamp> }
+200 OK { proof: "<proof>", validUntil: <UNIX timestamp>, approvedAt: <UNIX timestamp> }
 
 400 BAD REQUEST { }
 404 NOT FOUND { }
@@ -41,7 +41,8 @@ GET https://credentials.fractal.id/
 1. Change the first argument of `requiresCredential` (`expectedCredential`) based on your KYC level and country requirements.
     * Format: `<kycLevel>;not:<comma-separated country codes>` ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes).
 1. Set the last argument of `requiresCredential` (`maxAge`) to the maximum amount of time allowed to pass since KYC approval.
-  * In seconds (e.g. for 182 days use 15724800: `182*24*60*60`)
+  * In seconds (e.g. for `182` days, use `15724800`: `182*24*60*60`)
+  * Use `0` to skip this check (i.e. if it's not important how long ago the KYC was approved)
 
 <details>
   <summary>👁️ <strong>See example <code>(Solidity)</code></strong></summary>


### PR DESCRIPTION
Credential API now returns the timestamp of approval. This allows control over how old a verification can be in order for a transaction to be authorized.